### PR TITLE
fix bug in saveWorld()

### DIFF
--- a/src/hooks/useStore.js
+++ b/src/hooks/useStore.js
@@ -37,6 +37,7 @@ export const useStore = create((set) => ({
 	saveWorld: () => {
 		set((prev) => {
 			setLocalStorage('cubes', prev.cubes)
+			return prev
 		})
 	},
 	resetWorld: () => {


### PR DESCRIPTION
Error: Fix error `THREE.WebGLRenderer: Context Lost.` and `Uncaught TypeError: Cannot read properties of undefined (reading 'saveWorld')`


Credit to: "shin hang ja"'s comment in the video